### PR TITLE
Enhance ECR deployment stacks with appName and encryption options

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -4,3 +4,5 @@ POSTGRES_PASSWORD=mypassword
 CDK_DEPLOY_REGIONS=us-east-1,us-east-2,us-west-1,us-west-2
 ENVIRONMENTS=dev,stg,prod
 ECR_REPOSITORY_NAME=pgvectors-docker-image-erc-repository
+APP_NAME=pgvectors
+

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules
 cdk.out
 
 .env
+.aider*

--- a/bin/pgvectors-docker-image-ecr-deployment-cdk.ts
+++ b/bin/pgvectors-docker-image-ecr-deployment-cdk.ts
@@ -24,6 +24,7 @@ for (const cdkRegion of cdkRegions) {
                 environment,
             },
             repositoryName: `${process.env.ECR_REPOSITORY_NAME}-${environment}` || 'pgvectors-docker-image-ecr-deployment-cdk',
+            appName: process.env.APP_NAME || 'pgvectors',
         });
     }
 }

--- a/lib/PgvectorsDockerImageEcrDeploymentCdkStackProps.ts
+++ b/lib/PgvectorsDockerImageEcrDeploymentCdkStackProps.ts
@@ -1,0 +1,6 @@
+import * as cdk from 'aws-cdk-lib';
+
+export interface PgvectorsDockerImageEcrDeploymentCdkStackProps extends cdk.StackProps {
+    readonly repositoryName: string;
+    readonly appName: string;
+}

--- a/lib/pgvectors-docker-image-ecr-deployment-cdk-stack.ts
+++ b/lib/pgvectors-docker-image-ecr-deployment-cdk-stack.ts
@@ -4,25 +4,23 @@ import { Construct } from 'constructs';
 import * as ecrDeploy from 'cdk-ecr-deployment';
 import * as ecr from 'aws-cdk-lib/aws-ecr';
 import { DockerImageAsset } from 'aws-cdk-lib/aws-ecr-assets';
-
-export interface PgvectorsDockerImageEcrDeploymentCdkStackProps extends cdk.StackProps {
-    readonly repositoryName: string;
-}
+import { PgvectorsDockerImageEcrDeploymentCdkStackProps } from './PgvectorsDockerImageEcrDeploymentCdkStackProps';
 
 export class PgvectorsDockerImageEcrDeploymentCdkStack extends cdk.Stack {
-    constructor(scope: Construct, id: string, props?: PgvectorsDockerImageEcrDeploymentCdkStackProps) {
+    constructor(scope: Construct, id: string, props: PgvectorsDockerImageEcrDeploymentCdkStackProps) {
         super(scope, id, props);
 
-        const repo = new ecr.Repository(this, 'PgvectorsDockerImageEcrRepository', {
+        const repo = new ecr.Repository(this, `${props.appName}-PgvectorsDockerImageEcrRepository`, {
             repositoryName: props?.repositoryName || 'pgvectors-docker-image-ecr-deployment-cdk',
             removalPolicy: cdk.RemovalPolicy.DESTROY,
+            encryption: ecr.RepositoryEncryption.AES_256
         });
 
-        const image = new DockerImageAsset(this, 'PgvectorsDockerImageAsset', {
+        const image = new DockerImageAsset(this, `${props.appName}-PgvectorsDockerImageAsset`, {
             directory: path.join(__dirname, '../coreservices'),
         });
 
-        new ecrDeploy.ECRDeployment(this, 'PgvectorsDockerImageECRDeployment', {
+        new ecrDeploy.ECRDeployment(this, `${props.appName}-PgvectorsDockerImageECRDeployment`, {
             src: new ecrDeploy.DockerImageName(image.imageUri),
             dest: new ecrDeploy.DockerImageName(`${repo.repositoryUri}:latest`),
         });

--- a/lib/pgvectors-docker-image-ecr-kms-deployment-cdk-stack.ts
+++ b/lib/pgvectors-docker-image-ecr-kms-deployment-cdk-stack.ts
@@ -1,0 +1,36 @@
+import * as path from 'path';
+import * as cdk from 'aws-cdk-lib';
+import * as kms from 'aws-cdk-lib/aws-kms';
+import { Construct } from 'constructs';
+import * as ecrDeploy from 'cdk-ecr-deployment';
+import * as ecr from 'aws-cdk-lib/aws-ecr';
+import { DockerImageAsset } from 'aws-cdk-lib/aws-ecr-assets';
+import { PgvectorsDockerImageEcrDeploymentCdkStackProps } from './PgvectorsDockerImageEcrDeploymentCdkStackProps';
+
+export class PgvectorsDockerImageEcrDeploymentCdkStack extends cdk.Stack {
+    constructor(scope: Construct, id: string, props: PgvectorsDockerImageEcrDeploymentCdkStackProps) {
+        super(scope, id, props);
+
+        const kmsKey = new kms.Key(this, `${props.appName}-ECRRepositoryKmsKey`, {
+            enableKeyRotation: true,
+            removalPolicy: cdk.RemovalPolicy.DESTROY,
+            enabled: true,
+        });
+
+        const repo = new ecr.Repository(this, `${props.appName}-PgvectorsDockerImageEcrRepository`, {
+            repositoryName: props?.repositoryName || 'pgvectors-docker-image-ecr-deployment-cdk',
+            removalPolicy: cdk.RemovalPolicy.DESTROY,
+            encryption: ecr.RepositoryEncryption.KMS,
+            encryptionKey: kmsKey,
+        });
+
+        const image = new DockerImageAsset(this, `${props.appName}-PgvectorsDockerImageAsset`, {
+            directory: path.join(__dirname, '../coreservices'),
+        });
+
+        new ecrDeploy.ECRDeployment(this, `${props.appName}-PgvectorsDockerImageECRDeployment`, {
+            src: new ecrDeploy.DockerImageName(image.imageUri),
+            dest: new ecrDeploy.DockerImageName(`${repo.repositoryUri}:latest`),
+        });
+    }
+}

--- a/process-env.d.ts
+++ b/process-env.d.ts
@@ -4,5 +4,6 @@ declare module NodeJS {
         CDK_DEPLOY_REGIONS: string;
         ENVIRONMENTS: string;
         ECR_REPOSITORY_NAME: string;
+        APP_NAME: string;
     }
 }


### PR DESCRIPTION
## type:
enhancement, refactoring

___
## description:
- Extracted `PgvectorsDockerImageEcrDeploymentCdkStackProps` interface to a separate file for better modularity.
- Added `appName` to the ECR deployment stacks to prefix resources, allowing for unique naming based on the application name.
- Updated the ECR repository in the main stack to use AES_256 encryption.
- Created a new stack with KMS encryption for the ECR repository.
- Added `APP_NAME` environment variable to `.env.local` and `process-env.d.ts` for configuration.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `bin/pgvectors-docker-image-ecr-deployment-cdk.ts`: Added `appName` to the stack properties, which is derived from the `APP_NAME` environment variable or defaults to 'pgvectors'.
- `lib/PgvectorsDockerImageEcrDeploymentCdkStackProps.ts`: Created a new file to define the `PgvectorsDockerImageEcrDeploymentCdkStackProps` interface with `repositoryName` and `appName` properties.
- `lib/pgvectors-docker-image-ecr-deployment-cdk-stack.ts`: Imported `PgvectorsDockerImageEcrDeploymentCdkStackProps` from the new file.
Made `props` parameter mandatory in the constructor.
Prefixed resource names with `appName` and set the ECR repository to use AES_256 encryption.
- `lib/pgvectors-docker-image-ecr-kms-deployment-cdk-stack.ts`: Added a new stack that creates a KMS key for ECR repository encryption and deploys Docker images to the ECR repository.
- `process-env.d.ts`: Added `APP_NAME` to the `ProcessEnv` interface to support the new environment variable.
- `.env.local`: Added `APP_NAME` environment variable to the local environment configuration.
</details>
