### PR TITLE
Enhance ECR deployment with image versioning and retention rules

### DIFF
--- a/bin/pgvectors-docker-image-ecr-deployment-cdk.ts
+++ b/bin/pgvectors-docker-image-ecr-deployment-cdk.ts
@@ -10,8 +10,10 @@ const app = new cdk.App();
 
 const { CDK_DEFAULT_ACCOUNT: account, CDK_DEFAULT_REGION: region } = process.env;
 
-const cdkRegions = process.env.CDK_DEPLOY_REGIONS?.split(',') || [region]; // Parsing comma separated list of regions
-const environments = process.env.ENVIRONMENTS?.split(',') || ['dev']; // Parsing comma separated list of environments
+const cdkRegions = process.env.CDK_DEPLOY_REGIONS?.split(',') ?? [region]; // Parsing comma separated list of regions
+const environments = process.env.ENVIRONMENTS?.split(',') ?? ['dev']; // Parsing comma separated list of environments
+
+const DEFAULT_IMAGE_VERSION = 'latest';
 
 for (const cdkRegion of cdkRegions) {
     for (const environment of environments) {
@@ -23,9 +25,9 @@ for (const cdkRegion of cdkRegions) {
             tags: {
                 environment,
             },
-            repositoryName: `${process.env.ECR_REPOSITORY_NAME}-${environment}` || 'pgvectors-docker-image-ecr-deployment-cdk',
-            appName: process.env.APP_NAME || 'pgvectors',
-            imageVersion: process.env.IMAGE_VERSION || 'latest',
+            repositoryName: `${process.env.ECR_REPOSITORY_NAME}-${environment}` ?? 'pgvectors-docker-image-ecr-deployment-cdk',
+            appName: process.env.APP_NAME ?? 'pgvectors',
+            imageVersion: process.env.IMAGE_VERSION ?? DEFAULT_IMAGE_VERSION,
         });
     }
 }

--- a/bin/pgvectors-docker-image-ecr-deployment-cdk.ts
+++ b/bin/pgvectors-docker-image-ecr-deployment-cdk.ts
@@ -25,6 +25,7 @@ for (const cdkRegion of cdkRegions) {
             },
             repositoryName: `${process.env.ECR_REPOSITORY_NAME}-${environment}` || 'pgvectors-docker-image-ecr-deployment-cdk',
             appName: process.env.APP_NAME || 'pgvectors',
+            imageVersion: process.env.IMAGE_VERSION || 'latest',
         });
     }
 }

--- a/lib/PgvectorsDockerImageEcrDeploymentCdkStackProps.ts
+++ b/lib/PgvectorsDockerImageEcrDeploymentCdkStackProps.ts
@@ -3,4 +3,5 @@ import * as cdk from 'aws-cdk-lib';
 export interface PgvectorsDockerImageEcrDeploymentCdkStackProps extends cdk.StackProps {
     readonly repositoryName: string;
     readonly appName: string;
+    imageVersion?: string;
 }

--- a/lib/pgvectors-docker-image-ecr-deployment-cdk-stack.ts
+++ b/lib/pgvectors-docker-image-ecr-deployment-cdk-stack.ts
@@ -22,7 +22,7 @@ export class PgvectorsDockerImageEcrDeploymentCdkStack extends cdk.Stack {
 
         new ecrDeploy.ECRDeployment(this, `${props.appName}-PgvectorsDockerImageECRDeployment`, {
             src: new ecrDeploy.DockerImageName(image.imageUri),
-            dest: new ecrDeploy.DockerImageName(`${repo.repositoryUri}:latest`),
+            dest: new ecrDeploy.DockerImageName(`${repo.repositoryUri}:${props.imageVersion || 'latest'}`),
         });
     }
 }

--- a/lib/pgvectors-docker-image-ecr-deployment-cdk-stack.ts
+++ b/lib/pgvectors-docker-image-ecr-deployment-cdk-stack.ts
@@ -10,11 +10,14 @@ export class PgvectorsDockerImageEcrDeploymentCdkStack extends cdk.Stack {
     constructor(scope: Construct, id: string, props: PgvectorsDockerImageEcrDeploymentCdkStackProps) {
         super(scope, id, props);
 
-        const repo = new ecr.Repository(this, `${props.appName}-PgvectorsDockerImageEcrRepository`, {
+        const ecrRepository = new ecr.Repository(this, `${props.appName}-PgvectorsDockerImageEcrRepository`, {
             repositoryName: props?.repositoryName || 'pgvectors-docker-image-ecr-deployment-cdk',
             removalPolicy: cdk.RemovalPolicy.DESTROY,
             encryption: ecr.RepositoryEncryption.AES_256
         });
+
+        ecrRepository.addLifecycleRule({ maxImageCount: 4, rulePriority: 1, tagStatus: ecr.TagStatus.ANY }); // keep last 4 images
+        ecrRepository.addLifecycleRule({ maxImageAge: cdk.Duration.days(7), rulePriority: 2, tagStatus: ecr.TagStatus.ANY }); // delete images older than 7 days
 
         const image = new DockerImageAsset(this, `${props.appName}-PgvectorsDockerImageAsset`, {
             directory: path.join(__dirname, '../coreservices'),
@@ -22,7 +25,7 @@ export class PgvectorsDockerImageEcrDeploymentCdkStack extends cdk.Stack {
 
         new ecrDeploy.ECRDeployment(this, `${props.appName}-PgvectorsDockerImageECRDeployment`, {
             src: new ecrDeploy.DockerImageName(image.imageUri),
-            dest: new ecrDeploy.DockerImageName(`${repo.repositoryUri}:${props.imageVersion || 'latest'}`),
+            dest: new ecrDeploy.DockerImageName(`${ecrRepository.repositoryUri}:${props.imageVersion || 'latest'}`),
         });
     }
 }

--- a/lib/pgvectors-docker-image-ecr-deployment-cdk-stack.ts
+++ b/lib/pgvectors-docker-image-ecr-deployment-cdk-stack.ts
@@ -11,7 +11,7 @@ export class PgvectorsDockerImageEcrDeploymentCdkStack extends cdk.Stack {
         super(scope, id, props);
 
         const ecrRepository = new ecr.Repository(this, `${props.appName}-PgvectorsDockerImageEcrRepository`, {
-            repositoryName: props?.repositoryName || 'pgvectors-docker-image-ecr-deployment-cdk',
+            repositoryName: props?.repositoryName ?? 'pgvectors-docker-image-ecr-deployment-cdk',
             removalPolicy: cdk.RemovalPolicy.DESTROY,
             encryption: ecr.RepositoryEncryption.AES_256
         });
@@ -25,7 +25,7 @@ export class PgvectorsDockerImageEcrDeploymentCdkStack extends cdk.Stack {
 
         new ecrDeploy.ECRDeployment(this, `${props.appName}-PgvectorsDockerImageECRDeployment`, {
             src: new ecrDeploy.DockerImageName(image.imageUri),
-            dest: new ecrDeploy.DockerImageName(`${ecrRepository.repositoryUri}:${props.imageVersion || 'latest'}`),
+            dest: new ecrDeploy.DockerImageName(`${ecrRepository.repositoryUri}:${props.imageVersion}`),
         });
     }
 }

--- a/lib/pgvectors-docker-image-ecr-kms-deployment-cdk-stack.ts
+++ b/lib/pgvectors-docker-image-ecr-kms-deployment-cdk-stack.ts
@@ -17,12 +17,15 @@ export class PgvectorsDockerImageEcrDeploymentCdkStack extends cdk.Stack {
             enabled: true,
         });
 
-        const repo = new ecr.Repository(this, `${props.appName}-PgvectorsDockerImageEcrRepository`, {
-            repositoryName: props?.repositoryName || 'pgvectors-docker-image-ecr-deployment-cdk',
+        const ecrRepository = new ecr.Repository(this, `${props.appName}-PgvectorsDockerImageEcrRepository`, {
+            repositoryName: props?.repositoryName ?? 'pgvectors-docker-image-ecr-deployment-cdk',
             removalPolicy: cdk.RemovalPolicy.DESTROY,
             encryption: ecr.RepositoryEncryption.KMS,
             encryptionKey: kmsKey,
         });
+
+        ecrRepository.addLifecycleRule({ maxImageCount: 4, rulePriority: 1, tagStatus: ecr.TagStatus.ANY }); // keep last 4 images
+        ecrRepository.addLifecycleRule({ maxImageAge: cdk.Duration.days(7), rulePriority: 2, tagStatus: ecr.TagStatus.ANY }); // delete images older than 7 days
 
         const image = new DockerImageAsset(this, `${props.appName}-PgvectorsDockerImageAsset`, {
             directory: path.join(__dirname, '../coreservices'),
@@ -30,7 +33,7 @@ export class PgvectorsDockerImageEcrDeploymentCdkStack extends cdk.Stack {
 
         new ecrDeploy.ECRDeployment(this, `${props.appName}-PgvectorsDockerImageECRDeployment`, {
             src: new ecrDeploy.DockerImageName(image.imageUri),
-            dest: new ecrDeploy.DockerImageName(`${repo.repositoryUri}:${props.imageVersion || 'latest'}`),
+            dest: new ecrDeploy.DockerImageName(`${ecrRepository.repositoryUri}:${props.imageVersion}`),
         });
     }
 }

--- a/lib/pgvectors-docker-image-ecr-kms-deployment-cdk-stack.ts
+++ b/lib/pgvectors-docker-image-ecr-kms-deployment-cdk-stack.ts
@@ -30,7 +30,7 @@ export class PgvectorsDockerImageEcrDeploymentCdkStack extends cdk.Stack {
 
         new ecrDeploy.ECRDeployment(this, `${props.appName}-PgvectorsDockerImageECRDeployment`, {
             src: new ecrDeploy.DockerImageName(image.imageUri),
-            dest: new ecrDeploy.DockerImageName(`${repo.repositoryUri}:latest`),
+            dest: new ecrDeploy.DockerImageName(`${repo.repositoryUri}:${props.imageVersion || 'latest'}`),
         });
     }
 }

--- a/process-env.d.ts
+++ b/process-env.d.ts
@@ -5,5 +5,6 @@ declare module NodeJS {
         ENVIRONMENTS: string;
         ECR_REPOSITORY_NAME: string;
         APP_NAME: string;
+        IMAGE_VERSION: string;
     }
 }


### PR DESCRIPTION
## type:
enhancement

___
## description:
- Added the ability to specify an image version for ECR deployments, defaulting to 'latest' if not provided.
- Implemented retention rules for the ECR repository to keep the last 4 images and delete images older than 7 days.
- Introduced the IMAGE_VERSION environment variable to the process environment.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `bin/pgvectors-docker-image-ecr-deployment-cdk.ts`: - Added the `imageVersion` parameter to the ECR deployment configuration, which is set from the IMAGE_VERSION environment variable or defaults to 'latest'.
- `lib/PgvectorsDockerImageEcrDeploymentCdkStackProps.ts`: - Introduced an optional `imageVersion` property to the stack properties interface.
- `lib/pgvectors-docker-image-ecr-deployment-cdk-stack.ts`: - Renamed `repo` to `ecrRepository` for clarity.
- Added lifecycle rules to the ECR repository to limit the number of images retained and to remove images older than 7 days.
- Modified the ECR deployment to use the `imageVersion` property.
- `lib/pgvectors-docker-image-ecr-kms-deployment-cdk-stack.ts`: - Updated the ECR deployment to use the `imageVersion` property instead of hardcoding 'latest'.
- `process-env.d.ts`: - Added the `IMAGE_VERSION` environment variable to the NodeJS process environment interface.
</details>
