### PR TITLE
Scan image on push

### DIFF
--- a/lib/pgvectors-docker-image-ecr-deployment-cdk-stack.ts
+++ b/lib/pgvectors-docker-image-ecr-deployment-cdk-stack.ts
@@ -14,7 +14,8 @@ export class PgvectorsDockerImageEcrDeploymentCdkStack extends cdk.Stack {
             repositoryName: props.repositoryName,
             removalPolicy: cdk.RemovalPolicy.DESTROY,
             autoDeleteImages: true,
-            encryption: ecr.RepositoryEncryption.AES_256
+            encryption: ecr.RepositoryEncryption.AES_256,
+            imageScanOnPush: true,
         });
 
         ecrRepository.addLifecycleRule({ maxImageAge: cdk.Duration.days(7), rulePriority: 1, tagStatus: ecr.TagStatus.UNTAGGED }); // delete images older than 7 days

--- a/lib/pgvectors-docker-image-ecr-kms-deployment-cdk-stack.ts
+++ b/lib/pgvectors-docker-image-ecr-kms-deployment-cdk-stack.ts
@@ -21,6 +21,7 @@ export class PgvectorsDockerImageEcrDeploymentCdkStack extends cdk.Stack {
             repositoryName: props.repositoryName,
             removalPolicy: cdk.RemovalPolicy.DESTROY,
             autoDeleteImages: true,
+            imageScanOnPush: true,
             encryption: ecr.RepositoryEncryption.KMS,
             encryptionKey: kmsKey,
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pgvectors-docker-image-ecr-deployment-cdk",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pgvectors-docker-image-ecr-deployment-cdk",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dependencies": {
         "aws-cdk-lib": "2.113.0",
         "cdk-ecr-deployment": "^2.5.38",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pgvectors-docker-image-ecr-deployment-cdk",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "bin": {
     "pgvectors-docker-image-ecr-deployment-cdk": "bin/pgvectors-docker-image-ecr-deployment-cdk.js"
   },


### PR DESCRIPTION
## type:
enhancement

___
## description:
This PR introduces two main changes:
- It enables the image scanning on push for the ECR repositories. This is a security enhancement that will allow the system to automatically scan the Docker images for vulnerabilities whenever they are pushed to the repository.
- It updates the package version from 1.0.5 to 1.0.6 in both package.json and package-lock.json files.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `lib/pgvectors-docker-image-ecr-deployment-cdk-stack.ts`: Added the 'imageScanOnPush' property to the ECR repository configuration and set it to true, enabling automatic image scanning on push.
- `lib/pgvectors-docker-image-ecr-kms-deployment-cdk-stack.ts`: Similar to the previous file, the 'imageScanOnPush' property was added to the ECR repository configuration, enabling automatic image scanning on push.
- `package-lock.json`: Updated the package version from 1.0.5 to 1.0.6.
- `package.json`: Updated the package version from 1.0.5 to 1.0.6.
</details>
