### PR TITLE
Feature/GitHub action pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@ This repository contains the necessary infrastructure code to build and deploy a
 
 ![Xnapper-2023-01-15-23 41 21](https://github.com/tensorchord/pgvecto.rs/blob/main/docs/images/filter-benchmark.png)
 
+## Comparison with pgvector
+
+|                                             | pgvecto.rs                                             | pgvector                |
+| ------------------------------------------- | ------------------------------------------------------ | ----------------------- |
+| Transaction support                         | ✅                                                      | ⚠️                       |
+| Sufficient Result with Delete/Update/Filter | ✅                                                      | ⚠️                       |
+| Vector Dimension Limit                      | 65535                                                  | 2000                    |
+| Prefilter on HNSW                           | ✅                                                      | ❌                       |
+| Parallel HNSW Index build                   | ⚡️ Linearly faster with more cores                      | 🐌 Only single core used |
+| Async Index build                           | Ready for queries anytime and do not block insertions. | ❌                       |
+| Quantization                                | Scalar/Product Quantization                            | ❌                       |
+
+More details at [./docs/comparison-pgvector.md](./docs/comparison-pgvector.md)
+
 ## Project Structure
 
 - `bin/`: Contains the CDK entry point script.

--- a/lib/pgvectors-docker-image-ecr-deployment-cdk-stack.ts
+++ b/lib/pgvectors-docker-image-ecr-deployment-cdk-stack.ts
@@ -34,7 +34,7 @@ export class PgvectorsDockerImageEcrDeploymentCdkStack extends cdk.Stack {
             },
         });
 
-        const deployImageVersions = props.imageVersion === LATEST_IMAGE_VERSION ? props.imageVersion : [props.imageVersion, LATEST_IMAGE_VERSION];
+        const deployImageVersions = props.imageVersion === LATEST_IMAGE_VERSION ? [props.imageVersion] : [props.imageVersion, LATEST_IMAGE_VERSION];
         for (const deployImageVersion of deployImageVersions) {
             new ecrDeploy.ECRDeployment(this, `${props.appName}-${props.environment}-${deployImageVersion}-ECRDeployment`, {
                 src: new ecrDeploy.DockerImageName(dockerImageAsset.imageUri),

--- a/lib/pgvectors-docker-image-ecr-kms-deployment-cdk-stack.ts
+++ b/lib/pgvectors-docker-image-ecr-kms-deployment-cdk-stack.ts
@@ -41,7 +41,7 @@ export class PgvectorsDockerImageEcrDeploymentCdkStack extends cdk.Stack {
             },
         });
 
-        const deployImageVersions = props.imageVersion === LATEST_IMAGE_VERSION ? props.imageVersion : [props.imageVersion, LATEST_IMAGE_VERSION];
+        const deployImageVersions = props.imageVersion === LATEST_IMAGE_VERSION ? [props.imageVersion] : [props.imageVersion, LATEST_IMAGE_VERSION];
         for (const deployImageVersion of deployImageVersions) {
             new ecrDeploy.ECRDeployment(this, `${props.appName}-${props.environment}-${deployImageVersion}-ECRDeployment`, {
                 src: new ecrDeploy.DockerImageName(dockerImageAsset.imageUri),


### PR DESCRIPTION
## Type
Enhancement, Documentation


___

## Description
This PR introduces two main changes:
- It fixes a data type issue in the Docker image deployment scripts. The `deployImageVersions` variable is now always an array, even when the image version is the latest. This change affects both `pgvectors-docker-image-ecr-deployment-cdk-stack.ts` and `pgvectors-docker-image-ecr-kms-deployment-cdk-stack.ts` files.
- It expands the README documentation with a comparison table between `pgvecto.rs` and `pgvector`, providing more detailed information about these two options. The table includes aspects such as transaction support, result sufficiency, vector dimension limit, prefilter on HNSW, parallel HNSW index build, async index build, and quantization.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>pgvectors-docker-image-ecr-deployment-cdk-stack.ts&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        lib/pgvectors-docker-image-ecr-deployment-cdk-stack.ts<br><br>
        <strong>The `deployImageVersions` variable is now always an array, <br>even when the image version is the latest.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/AI4Organization/pgvectors-docker-image-ecr-deployment-cdk/pull/22/files#diff-a93827075497adb956c46a8aa9772d270502fbbf285d878e89fd3baab2873d78"> +1/-1</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>pgvectors-docker-image-ecr-kms-deployment-cdk-stack.ts&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        lib/pgvectors-docker-image-ecr-kms-deployment-cdk-stack.ts<br><br>
        <strong>The `deployImageVersions` variable is now always an array, <br>even when the image version is the latest.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/AI4Organization/pgvectors-docker-image-ecr-deployment-cdk/pull/22/files#diff-0dc5c2f3cc2dcba00213d8fd47bbe5a93afb879581073769724d77354d7adf93"> +1/-1</a></td>

</tr>                    
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        README.md<br><br>
        <strong>Added a comparison table between `pgvecto.rs` and <br>`pgvector`, providing more detailed information about these <br>two options.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/AI4Organization/pgvectors-docker-image-ecr-deployment-cdk/pull/22/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5"> +14/-0</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>